### PR TITLE
feat: add isp info, synced attribute to node page

### DIFF
--- a/app/routes/node.$id.tsx
+++ b/app/routes/node.$id.tsx
@@ -116,6 +116,9 @@ function Node() {
         <Col label="Last Seen:" value={formatISO9075(new Date(nodeData.last_seen.split('.')[0].replace(' ', 'T')), { representation: "date" })} />
         <Col label="Country:" value={nodeData.country} />
         <Col label="City:" value={nodeData.city} />
+        <Col label="Synced:" value={String(nodeData.synced || false)} />
+        <Col label="ISP:" value={String(nodeData.isp || "")} />
+
       </div>
     </div>
   );

--- a/app/types.d.ts
+++ b/app/types.d.ts
@@ -39,4 +39,6 @@ type NodeRecord = {
   last_seen: string;
   country: string;
   city: string;
+  isp: string;
+  synced: boolean;
 };


### PR DESCRIPTION
fixes #13 - deployed locally using `npm run dev` on both chrome/brave and safari:
<img width="866" alt="Screen Shot 2023-11-10 at 11 27 57 PM" src="https://github.com/Keep-Reth-Strange/reth-crawler-frontend/assets/134806363/f74b2097-4514-43d4-b93b-c0dacff71658">
