### PR TITLE
fix: on node info page show complete datetime

### DIFF
--- a/app/routes/node.$id.tsx
+++ b/app/routes/node.$id.tsx
@@ -113,7 +113,7 @@ function Node() {
         <Col label="Total Difficulty:" value={nodeData.total_difficulty} />
         <Col label="Best Block:" value={nodeData.best_block} />
         <Col label="Genesis Block Hash:" value={nodeData.genesis_block_hash} />
-        <Col label="Last Seen:" value={formatISO9075(new Date(nodeData.last_seen.split('.')[0].replace(' ', 'T')), { representation: "date" })} />
+        <Col label="Last Seen:" value={formatISO9075(new Date(nodeData.last_seen.split('.')[0].replace(' ', 'T')), { representation: "complete" })} />
         <Col label="Country:" value={nodeData.country} />
         <Col label="City:" value={nodeData.city} />
         <Col label="Synced:" value={String(nodeData.synced || false)} />


### PR DESCRIPTION
<img width="290" alt="Screen Shot 2023-11-10 at 11 43 58 PM" src="https://github.com/Keep-Reth-Strange/reth-crawler-frontend/assets/134806363/1321e183-6bc6-4cbf-8550-a3927e112cd8">
